### PR TITLE
 finish refactor asset invite.

### DIFF
--- a/ui/src/components/AssetDetails/AssetDetails.tsx
+++ b/ui/src/components/AssetDetails/AssetDetails.tsx
@@ -28,9 +28,10 @@ export interface AssetDetailsProps {
   ticker: string;
   issuer: string;
   owner: string;
-  quantity: string;
-  isFungible: boolean;
-  // belong to asset account
+  // optional because for account invite, there is no quantity
+  quantity?: string;
+  isFungible?: boolean;
+  // optional because template Asset won't have these attributes
   isShareable?: boolean;
   isAirdroppable?: boolean;
 }

--- a/ui/src/components/PendingAccountInviteRow/PendingAccountInviteRow.tsx
+++ b/ui/src/components/PendingAccountInviteRow/PendingAccountInviteRow.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import Button from '@mui/material/Button';
+import SendIcon from '@mui/icons-material/Send';
+import { Link } from "react-router-dom";
+import { SendRowContents } from '../SendRowContents/SendRowContents';
+import { Avatar, Box, CardActionArea, IconButton, Typography } from '@mui/material';
+import { isMobile } from '../../platform/platform';
+import { useNarrowPendingStyles } from '../PendingRowContents/PendingRowContents';
+import { createQueriesString } from '../../utils/createQueriesString';
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
+import { PendingAssetInviteRowContent } from '../PendingAssetInviteRowContent/PendingAssetInviteRowContent';
+
+export interface PendingAccountInviteRow {
+  sender: string;
+  receiver: string;
+  isNarrow: boolean;
+  isInbound: boolean;
+  accountInviteCid:string;
+  owner: string;
+  // assetType
+  symbol: string;
+  issuer: string;
+  isFungible: boolean;
+  reference: string;
+  isAirdroppable: boolean;
+  isShareable: boolean;
+
+}
+
+export const PendingAccountInviteRow: React.FC<PendingAccountInviteRow> = (props) => {
+  const classes = useNarrowPendingStyles();
+  const {
+    isAirdroppable, 
+    isShareable, 
+    owner, 
+    isFungible, 
+    reference, 
+    accountInviteCid, 
+    issuer, 
+    symbol, 
+    sender, 
+    receiver, 
+    isNarrow, 
+    isInbound
+  } = props;
+  console.log(props)
+
+  const onAccept = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+  }
+
+  const onCancel = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+  }
+  const onReject = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+  }
+  const queriesInput = [
+    ['sender', sender],
+    ['receiver', receiver],
+    ['symbol', symbol],
+    ['issuer', issuer],
+    ['contractId', accountInviteCid],
+    ['templateName', 'accountInvite'],
+    ['isFungible', isFungible ? 'true' : 'false'],
+    ['reference', reference as string],
+    ['isAirdroppable', `${isAirdroppable}`],
+    ['owner', owner],
+    ['isInbound', `${isInbound}`],
+    ['isShareable', `${isShareable}`]
+  ]
+  const queries = createQueriesString(queriesInput)
+  const path = `/pending-activity?` + queries
+  console.log(path)
+  return (
+    <>
+      <Card className={classes.card}>
+        <CardActionArea component={Link} to={path}>
+          <div className={classes.symbolTextContainer} >
+            <Avatar className={classes.avatar}>
+              <AccountBalanceWalletIcon />
+            </Avatar>
+            <PendingAssetInviteRowContent issuer={issuer} receiver={receiver} isInbound={isInbound} sender={sender} inboundTicker={symbol}/>  
+            {!isMobile() && <div className={classes.actions}>
+              {isInbound && <Button className={classes.button} variant='outlined' size="small" onClick={onAccept}>Accept</Button>}
+              <Button onClick={isInbound ? onReject : onCancel} className={classes.button} variant='outlined' size="small">{isInbound ? 'Reject Request' : 'Cancel Request'}</Button>
+              <Button className={classes.button} variant='outlined' size="small"
+              >Details</Button>
+            </div>}
+          </div>
+        </CardActionArea>
+      </Card>
+    </>
+  );
+}

--- a/ui/src/components/PendingAccountInvites/PendingAccountInvites.tsx
+++ b/ui/src/components/PendingAccountInvites/PendingAccountInvites.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Card, CardContent, LinearProgress } from '@mui/material';
+import { PendingActivitiesPageProps } from '../PendingActivities/PendingActivities';
+import { useGetAssetInviteRequests } from '../../ledgerHooks/ledgerHooks';
+import { PendingAccountInviteRow } from '../PendingAccountInviteRow/PendingAccountInviteRow';
+
+
+
+export const PendingAccountInvites: React.FC<PendingActivitiesPageProps> = (props) => {
+  const {isInbound} = props;
+  const {loading, contracts} = useGetAssetInviteRequests(isInbound);
+  const accountInviteRows = contracts.map((contract) => {
+  const {
+    symbol,
+    issuer, 
+    fungible, 
+    reference
+  } = contract.payload.account.assetType
+  
+  const {
+    owner,
+    airdroppable,
+    resharable
+  } = contract.payload.account
+
+  const receiver = contract.payload.recipient
+  const accountInviteCid = contract.contractId;
+  const sender = contract.signatories[0];
+  const pendingAccountInviteRowProps = {
+    symbol, 
+    issuer, 
+    isFungible: fungible, 
+    reference: reference as string,
+    isInbound,
+    owner,
+    isAirdroppable: airdroppable,
+    isShareable: resharable,
+    receiver,
+    isNarrow: true,
+    accountInviteCid,
+    sender
+  }
+
+    return (
+      <PendingAccountInviteRow {...pendingAccountInviteRowProps} />
+    )
+  })
+  
+  if(loading){
+    return <LinearProgress/>
+  }
+  if(contracts.length === 0){
+    return (
+      <Card sx={{margin: 1, width: '100%'}}>
+        <CardContent>
+          No pending Account Invites
+        </CardContent>
+      </Card>
+    )
+  }
+  
+  return ( 
+    <>
+    {accountInviteRows}
+    </>
+  )
+}

--- a/ui/src/components/PendingActivities/PendingActivities.tsx
+++ b/ui/src/components/PendingActivities/PendingActivities.tsx
@@ -3,10 +3,11 @@ import { useParty } from '@daml/react';
 import { ContractId } from '@daml/types';
 import React from 'react';
 import { useGetAllAssetAccounts, useGetAssetInviteRequests, useGetAssetSendRequests, useGetAssetSwapRequests } from '../../ledgerHooks/ledgerHooks';
+import { PendingAccountInvites } from '../PendingAccountInvites/PendingAccountInvites';
 import { PendingRow } from '../PendingRow/PendingRow';
 import { PendingTransfers } from '../PendingTransfers/PendingTransfers';
 
-interface PendingActivitiesPageProps {
+export interface PendingActivitiesPageProps {
   isInbound: boolean;
 }
 
@@ -107,7 +108,7 @@ export const PendingActivities: React.FC<PendingActivitiesPageProps> = ({isInbou
   return (
     <>
     <PendingTransfers isInbound={isInbound}/>
-      {pendingRows}
+    <PendingAccountInvites isInbound={isInbound}/>
     </>
   )
 }

--- a/ui/src/components/PendingAssetInviteRowContent/PendingAssetInviteRowContent.tsx
+++ b/ui/src/components/PendingAssetInviteRowContent/PendingAssetInviteRowContent.tsx
@@ -6,7 +6,13 @@ import clx from 'clsx'
 import { useNarrowPendingStyles } from '../PendingRowContents/PendingRowContents';
 import { PendingRowProps } from '../PendingRow/PendingRow';
 
-export const PendingAssetInviteRowContent: React.FC<PendingRowProps> = ({ isInbound, sender, inboundTicker, receiver }) => {
+export const PendingAssetInviteRowContent: React.FC<PendingRowProps> = (props) => {
+  const { 
+    isInbound, 
+    sender, 
+    inboundTicker, 
+    receiver 
+  } = props
   const classes = useNarrowPendingStyles();
 
   const inboundMessage = (

--- a/ui/src/pages/PendingActivityDetailsPage/PendingActivityDetailsPage.tsx
+++ b/ui/src/pages/PendingActivityDetailsPage/PendingActivityDetailsPage.tsx
@@ -104,34 +104,19 @@ export const PendingActivityDetailsPage: React.FC = () => {
   const isFungible = query.get('isFungible') === 'true';
   const isAirdroppable = query.get('isAirdroppable') === 'true'
   const outboundQuantity = query.get('outboundQuantity')
+  
   const sender = query.get('sender');
   const symbol = query.get('symbol');
   const amount = query.get('amount');
   const owner = query.get('owner');
 
-  const props = {
-    sender, 
-    inboundQuantity,
-    inboundTicker,
-    outboundTicker,
-    outboundQuantity,
-    issuer,
-    isFungible,
-    isAirdroppable,
-    isShareable,
-    sendAmount,
-    sendTicker,
-    contractId,
-    owner: myPartyId,
-    isInbound, 
-    recipient
-  }
   console.log(symbol, amount,owner)
   
   if(actionLabel === 'send' &&
     symbol !== null &&
     amount !== null &&
-    owner !== null
+    owner !== null && 
+    contractId !== null
   ){
     return <PendingSendDetailsPage
     contractId={contractId}
@@ -142,14 +127,24 @@ export const PendingActivityDetailsPage: React.FC = () => {
     isFungible={isFungible}
     issuer={issuer}
     owner={owner}
-
-
-    
     />
   }
-  if(actionLabel ==='assetInvite'){
+  if(actionLabel ==='accountInvite' &&
+    sender !== null &&
+    symbol !== null &&
+    owner !== null && 
+    contractId !== null
+  ){
     return <PendingAssetInviteDetailsPage
-    {...props}
+      sender={sender}
+      recipient={recipient}
+      isInbound={isInbound}
+      symbol={symbol}
+      issuer={issuer}
+      isAirdroppable={isAirdroppable}
+      isShareable={isShareable}
+      owner={owner}
+      contractId={contractId}
     />
   }
   if(actionLabel ==='swap'){
@@ -158,7 +153,6 @@ export const PendingActivityDetailsPage: React.FC = () => {
   return (
     <Card sx={{margin: 1, width: '100%'}}>
       <CardContent>
-
       Page doesn't exist
       </CardContent>
     </Card>

--- a/ui/src/pages/PendingSendDetailsPage.tsx
+++ b/ui/src/pages/PendingSendDetailsPage.tsx
@@ -35,7 +35,7 @@ const successMessage: Success = {
   cancel: 'canceled'
 }
 interface PendingSendDetailsPageProps {
-  contractId: any;
+  contractId: string;
   isInbound: string;
   recipient: string;
   symbol: string;


### PR DESCRIPTION
* make typings more strict for components
* extract account invite to its own component, more code, but more easily read with less optional types