### PR TITLE
Make obvious the need for AssetHoldingAccount to accept transfer

### DIFF
--- a/ui/src/components/SendForm/SendForm.tsx
+++ b/ui/src/components/SendForm/SendForm.tsx
@@ -12,7 +12,7 @@ import { ContractId } from '@daml/types';
 import { AssetHoldingAccount } from '@daml.js/wallet-refapp/lib/Account';
 import { getAssetSum } from '../../utils/getAssetSum';
 import { numberWithCommas } from '../../utils/numberWithCommas';
-
+import InfoIcon from '@mui/icons-material/Info';
 interface SendFormProps {
   ticker: string;
   isAirdroppable: boolean;
@@ -106,11 +106,10 @@ export const SendForm: React.FC<SendFormProps> = (props) => {
           </Typography>
         </Box>
         <TextField
-          
           disabled={isLoading || isSuccessful}
           margin="normal"
           id="recipient"
-          label="Recipient"
+          label="Recipient's LedgerID"
           type="text"
           value={recipient}
           fullWidth
@@ -118,6 +117,8 @@ export const SendForm: React.FC<SendFormProps> = (props) => {
           size='small'
           onChange={(e) => setRecipient(e.currentTarget.value)}
         />
+          
+        
         <TextField
           disabled={isLoading || isSuccessful}
           margin="none"
@@ -137,10 +138,15 @@ export const SendForm: React.FC<SendFormProps> = (props) => {
           }}
         />
         <Card elevation={0} variant='outlined' className={classes.helpMessage}>
+          <Box display='flex' alignItems='center' margin={1}>
+          <InfoIcon color='primary' sx={{marginRight:1}}/> <Typography variant='body2'><i>Please note</i></Typography>
+            </Box>
+        <Typography color='text.primary' variant='body2' p={1}>
+          If you have not invited this user as an owner for the AssetHoldingAccount {ticker}, please do so first by going "back" and clicking "Invite". Otherwise the recipient will not be able to accept this asset.
+        </Typography>
           <Typography color='text.primary' variant='body2' p={1}>
-            This is a one-off send. This means when you send to the specified user,
-            they must accept it first in order for the ownership of the asset to be transferred.
-            This uses the 'propose and accept' pattern. Learn more about this pattern <Link target="_blank" href="https://docs.daml.com/daml/patterns/initaccept.html">here</Link>.
+            An assetTransferProposal template is created upon clicking send. The recipient will need to accept this request first before the ownership of the asset is transferred.
+             <Link target="_blank" href="https://docs.daml.com/daml/patterns/initaccept.html">here</Link>.
         </Typography>
         </Card>
         <LoadingButton

--- a/ui/src/ledgerHooks/ledgerHooks.ts
+++ b/ui/src/ledgerHooks/ledgerHooks.ts
@@ -78,7 +78,7 @@ export interface AssetType {
   fungible: boolean;
   reference: string;
 }
-export const useGetAssetAccountByKey = (assetType: AssetType) => {
+export const useGetMyAssetAccountByKey = (assetType: AssetType) => {
   const myPartyId = useParty();
   const contract = useFetchByKey(Account.AssetHoldingAccount, () => ({ _1: assetType, _2: myPartyId }), []);
   return contract

--- a/ui/src/pages/AssetProfilePage.tsx
+++ b/ui/src/pages/AssetProfilePage.tsx
@@ -15,7 +15,7 @@ import { enableFabBack } from './IssueAirdropPage';
 import { chipColors } from '../components/RowChip/RowChip';
 import { useParty } from '@daml/react';
 import { numberWithCommas } from '../utils/numberWithCommas';
-import { useGetAssetAccountByKey, useGetMyOwnedAssetsByAssetType } from '../ledgerHooks/ledgerHooks';
+import { useGetMyAssetAccountByKey, useGetMyOwnedAssetsByAssetType } from '../ledgerHooks/ledgerHooks';
 import { getAssetSum } from '../utils/getAssetSum';
 import { useQuery } from './PendingActivityDetailsPage/PendingActivityDetailsPage';
 import { FloatingBackButton } from '../components/FloatingBackButton/FloatingBackButton';
@@ -95,7 +95,7 @@ export const AssetProfilePage: React.FC = () => {
   const issuer = query.get('issuer') || ""
   const symbol = query.get('ticker') || ""
   const isFungible = query.get('isFungible') === 'true'
-  const { contract: assetAccountContract } = useGetAssetAccountByKey({ issuer, symbol, fungible: isFungible, reference })
+  const { contract: assetAccountContract } = useGetMyAssetAccountByKey({ issuer, symbol, fungible: isFungible, reference })
   const contractId = query.get('contractId');
   const isShareable = assetAccountContract?.payload.resharable
   const isAirdroppable = assetAccountContract?.payload.airdroppable

--- a/ui/src/pages/PendingSendDetailsPage.tsx
+++ b/ui/src/pages/PendingSendDetailsPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {  useNavigate } from 'react-router-dom'
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import { Avatar, Box, Button, Card, CardContent, IconButton, Typography } from '@mui/material';
-import { useGetAssetAccountByKey, useGetAssetTransferByContractId, useLedgerHooks } from '../ledgerHooks/ledgerHooks';
+import { useGetMyAssetAccountByKey, useGetAssetTransferByContractId, useLedgerHooks } from '../ledgerHooks/ledgerHooks';
 import { usePageStyles } from './PendingActivityDetailsPage/PendingActivityDetailsPage';
 import { AssetDetails } from '../components/AssetDetails/AssetDetails';
 import { isMobile } from '../platform/platform';
@@ -68,13 +68,14 @@ export const PendingSendDetailsPage: React.FC<PendingSendDetailsPageProps> = (pr
   //TODO: can we use something else besdies contract
   const assetTransferResponse = useGetAssetTransferByContractId({contractId: contractId as ContractId<AssetTransfer>});
   const assetTransferCid = assetTransferResponse.contract?.contractId
-  const assetAccountResponse = useGetAssetAccountByKey({issuer, symbol, fungible: isFungible, reference})
+  const assetAccountResponse = useGetMyAssetAccountByKey({issuer, symbol, fungible: isFungible, reference})
   const assetAccountCid = assetAccountResponse.contract?.contractId
   const classes = usePageStyles();
   const ledgerHooks = useLedgerHooks();
   const onBack = () => {
     nav(-1)
   }
+  
   if(!assetTransferCid){
     return (
       <Card sx={{width: '100%', margin: 1}}>
@@ -158,7 +159,7 @@ export const PendingSendDetailsPage: React.FC<PendingSendDetailsPageProps> = (pr
                 { symbol || '[TickerName]'}
               </Typography>
             </div>
-             <AssetDetails issuer={issuer} owner={owner} isFungible={isFungible}  quantity={amount} ticker={symbol || '[Ticker]'} />
+             <AssetDetails reference={reference} issuer={issuer} owner={owner} isFungible={isFungible}  quantity={amount} ticker={symbol || '[Ticker]'} />
           </CardContent>
           {
             success && !!successMessage[success] && <Card sx={{margin: 1}}><CardContent>{successMessage[success]}</CardContent></Card>
@@ -166,11 +167,14 @@ export const PendingSendDetailsPage: React.FC<PendingSendDetailsPageProps> = (pr
           {
             error && !!errors[error] && <Card sx={{margin: 1}}><CardContent>{errors[error]}</CardContent></Card>
           }
+          {
+            !assetAccountCid && <Card sx={{margin: 1, maxWidth: '500px'}}><CardContent>You do not have an Asset Holding Account for this asset. Please ask the sender of this asset to invite you as an asset holder.</CardContent></Card>
+          }
           {success === undefined && <div className={classes.actions}>
-            {isInbound === 'true' && <LoadingButton loadingPosition='end' loading={isLoading === 'accept'} onClick={onAccept} fullWidth sx={{marginLeft: 1, marginRight: 1 }} variant='outlined'  >
+            {isInbound === 'true' && <LoadingButton disabled={!assetAccountCid} loadingPosition='end' loading={isLoading === 'accept'} onClick={onAccept} fullWidth sx={{marginLeft: 1, marginRight: 1 }} variant='outlined'  >
               Accept Request
             </LoadingButton>}
-            {isInbound === 'true' && <LoadingButton loadingPosition='end' loading={isLoading === 'reject'} fullWidth onClick={() => onClick('reject')} sx={{ marginRight: 1 }} variant='outlined'>
+            {isInbound === 'true' && <LoadingButton disabled={!assetAccountCid} loadingPosition='end' loading={isLoading === 'reject'} fullWidth onClick={() => onClick('reject')} sx={{ marginRight: 1 }} variant='outlined'>
               Reject Request
           </LoadingButton>}
           {isInbound === 'false' && success !== 'cancel' && <LoadingButton  loadingPosition='end' loading={isLoading === 'cancel'} onClick={() => {onClick('cancel')}} fullWidth sx={{ margin: 1 }} variant='outlined'>

--- a/ui/src/pages/SwapPage.tsx
+++ b/ui/src/pages/SwapPage.tsx
@@ -8,7 +8,7 @@ import { isMobile } from '../platform/platform';
 import { enableFabBack } from './IssueAirdropPage';
 import { FloatingBackButton } from '../components/FloatingBackButton/FloatingBackButton';
 import { useQuery } from './PendingActivityDetailsPage/PendingActivityDetailsPage';
-import { useGetAssetAccountByKey, useGetMyOwnedAssetsByAssetType } from '../ledgerHooks/ledgerHooks';
+import { useGetMyAssetAccountByKey, useGetMyOwnedAssetsByAssetType } from '../ledgerHooks/ledgerHooks';
 import { useParty } from '@daml/react';
 
 
@@ -22,7 +22,7 @@ export const SwapPage: React.FC = () => {
   const symbol = query.get('ticker') || ""
   const isFungible = query.get('isFungible') === 'true'
   // get your owned asset account
-  const { loading: assetAccountContractLoading} = useGetAssetAccountByKey({issuer, symbol, fungible: isFungible, reference})
+  const { loading: assetAccountContractLoading} = useGetMyAssetAccountByKey({issuer, symbol, fungible: isFungible, reference})
 
   const { loading: assetContractsLoading} = useGetMyOwnedAssetsByAssetType({ issuer, symbol, isFungible, owner: party, reference });
 


### PR DESCRIPTION
* was not obvious in the UI that an asseteholdingaccount is required to accept a transfer
* Not obvious in the UI that the sender of the asset needs to first invite the recipient as an owner
*